### PR TITLE
filter: enable percentage based rollouts

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -28,6 +28,29 @@ func Test_filter(t *testing.T) {
 	}
 }
 
+func Test_filter_RolloutPercentage(t *testing.T) {
+	rawFilterResp := []byte(`{"filter":null,"rollout":"MkVpBxSg9TI="}`)
+	fr := &filterResponse{}
+	if err := json.Unmarshal(rawFilterResp, fr); err != nil {
+		t.Fatalf("failed to decode json: %v", err)
+	}
+
+	f, err := from(fr)
+	if err != nil {
+		t.Fatalf("failed to create filter from response: %v", err)
+	}
+
+	key1 := []byte("test_team_feature:user:1") // hash mod 100 becomes 74.
+	key2 := []byte("test_team_feature:user:4") // hash mod 100 becomes 41.
+
+	if v := f.lookup(key1); v {
+		t.Errorf("expected %s to be false but got %v", key1, v)
+	}
+	if v := f.lookup(key2); !v {
+		t.Errorf("expected %s to be true but got %v", key2, v)
+	}
+}
+
 func Test_filter_RolloutOnly(t *testing.T) {
 	rawFilterResp := []byte(`{"filter":null,"rollout":"ZPPzHfbwt2xk7lAWLwPCQgE+Qryr1ydL"}`)
 	fr := &filterResponse{}


### PR DESCRIPTION
Currently, we only support checking if a feature is fully rolled out. This change gives us percentage based rollouts by getting the last two digits from the full computed hash of the flag, and checking if it's less than the rollout percentage.

This is fine for now, but I need to check if the distribution for those two digits is consistent enough to actually use this forever. It may be that the distribution is uneven.